### PR TITLE
[0.4.2] Support macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2 (2023-11-26)
+
+* Support macOS, watchOS, and tvOS
+
 ## 0.4.1 (2020-9-21)
 
 * Support SPM

--- a/ColorThiefSwift.podspec
+++ b/ColorThiefSwift.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ColorThiefSwift'
-  s.version          = '0.4.1'
+  s.version          = '0.4.2'
   s.summary          = 'Grabs the dominant color or a representative color palette from an image.'
 
 # This description is used to generate tags and improve search results.
@@ -31,6 +31,8 @@ A Swift port of same name libraries of JavaScript and Java.
 
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '2.0'
+  s.macos.deployment_target = '10.11'
   s.swift_version = '5.0'
 
   s.source_files = 'ColorThiefSwift/Classes/**/*'
@@ -40,6 +42,9 @@ A Swift port of same name libraries of JavaScript and Java.
   # }
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
-  s.frameworks = 'UIKit'
+  s.ios.frameworks = 'UIKit'
+  s.tvos.frameworks = 'UIKit'
+  s.watchos.frameworks = 'UIKit'
+  s.macos.frameworks = 'AppKit'
   # s.dependency 'AFNetworking', '~> 2.3'
 end

--- a/ColorThiefSwift/Classes/ColorThief.swift
+++ b/ColorThiefSwift/Classes/ColorThief.swift
@@ -103,7 +103,20 @@ public class ColorThief {
             return nil
         }
         #elseif canImport(AppKit)
-        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+        guard let rawCGImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return nil
+        }
+        let colorSpace = NSColorSpace.sRGB
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+        let context = CGContext(data: nil,
+                                width: rawCGImage.width,
+                                height: rawCGImage.height,
+                                bitsPerComponent: rawCGImage.bitsPerComponent,
+                                bytesPerRow: rawCGImage.bytesPerRow,
+                                space: colorSpace.cgColorSpace!,
+                                bitmapInfo: bitmapInfo.rawValue)
+        context?.draw(rawCGImage, in: CGRect(x: 0, y: 0, width: CGFloat(rawCGImage.width), height: CGFloat(rawCGImage.height)))
+        guard let cgImage = context?.makeImage() else {
             return nil
         }
         #endif

--- a/ColorThiefSwift/Classes/ColorThief.swift
+++ b/ColorThiefSwift/Classes/ColorThief.swift
@@ -103,20 +103,7 @@ public class ColorThief {
             return nil
         }
         #elseif canImport(AppKit)
-        guard let rawCGImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
-            return nil
-        }
-        let colorSpace = NSColorSpace.sRGB
-        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
-        let context = CGContext(data: nil,
-                                width: rawCGImage.width,
-                                height: rawCGImage.height,
-                                bitsPerComponent: rawCGImage.bitsPerComponent,
-                                bytesPerRow: rawCGImage.bytesPerRow,
-                                space: colorSpace.cgColorSpace!,
-                                bitmapInfo: bitmapInfo.rawValue)
-        context?.draw(rawCGImage, in: CGRect(x: 0, y: 0, width: CGFloat(rawCGImage.width), height: CGFloat(rawCGImage.height)))
-        guard let cgImage = context?.makeImage() else {
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
             return nil
         }
         #endif

--- a/ColorThiefSwift/Classes/ColorThief.swift
+++ b/ColorThiefSwift/Classes/ColorThief.swift
@@ -17,7 +17,19 @@
 //  Sven Woltmann - for the fast Java Implementation
 //  https://github.com/SvenWoltmann/color-thief-java
 
+#if canImport(UIKit)
 import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+#if canImport(UIKit)
+public typealias PlatformNativeImage = UIImage
+public typealias PlatformNativeColor = UIColor
+#elseif canImport(AppKit)
+public typealias PlatformNativeImage = NSImage
+public typealias PlatformNativeColor = NSColor
+#endif
 
 public class ColorThief {
 
@@ -36,7 +48,7 @@ public class ColorThief {
     ///              color.
     ///   - ignoreWhite: if true, white pixels are ignored
     /// - Returns: the dominant color
-    public static func getColor(from image: UIImage, quality: Int = defaultQuality, ignoreWhite: Bool = defaultIgnoreWhite) -> MMCQ.Color? {
+    public static func getColor(from image: PlatformNativeImage, quality: Int = defaultQuality, ignoreWhite: Bool = defaultIgnoreWhite) -> MMCQ.Color? {
         guard let palette = getPalette(from: image, colorCount: 5, quality: quality, ignoreWhite: ignoreWhite) else {
             return nil
         }
@@ -57,7 +69,7 @@ public class ColorThief {
     ///              likelihood that colors will be missed.
     ///   - ignoreWhite: if true, white pixels are ignored
     /// - Returns: the palette
-    public static func getPalette(from image: UIImage, colorCount: Int, quality: Int = defaultQuality, ignoreWhite: Bool = defaultIgnoreWhite) -> [MMCQ.Color]? {
+    public static func getPalette(from image: PlatformNativeImage, colorCount: Int, quality: Int = defaultQuality, ignoreWhite: Bool = defaultIgnoreWhite) -> [MMCQ.Color]? {
         guard let colorMap = getColorMap(from: image, colorCount: colorCount, quality: quality, ignoreWhite: ignoreWhite) else {
             return nil
         }
@@ -77,7 +89,7 @@ public class ColorThief {
     ///              likelihood that colors will be missed.
     ///   - ignoreWhite: if true, white pixels are ignored
     /// - Returns: the color map
-    public static func getColorMap(from image: UIImage, colorCount: Int, quality: Int = defaultQuality, ignoreWhite: Bool = defaultIgnoreWhite) -> MMCQ.ColorMap? {
+    public static func getColorMap(from image: PlatformNativeImage, colorCount: Int, quality: Int = defaultQuality, ignoreWhite: Bool = defaultIgnoreWhite) -> MMCQ.ColorMap? {
         guard let pixels = makeBytes(from: image) else {
             return nil
         }
@@ -85,10 +97,16 @@ public class ColorThief {
         return colorMap
     }
 
-    static func makeBytes(from image: UIImage) -> [UInt8]? {
+    static func makeBytes(from image: PlatformNativeImage) -> [UInt8]? {
+        #if canImport(UIKit)
         guard let cgImage = image.cgImage else {
             return nil
         }
+        #elseif canImport(AppKit)
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return nil
+        }
+        #endif
         if isCompatibleImage(cgImage) {
             return makeBytesFromCompatibleImage(cgImage)
         } else {

--- a/ColorThiefSwift/Classes/MMCQ.swift
+++ b/ColorThiefSwift/Classes/MMCQ.swift
@@ -61,6 +61,16 @@ open class MMCQ {
         public func makePlatformNativeColor() -> PlatformNativeColor {
             return PlatformNativeColor(red: CGFloat(r) / CGFloat(255), green: CGFloat(g) / CGFloat(255), blue: CGFloat(b) / CGFloat(255), alpha: CGFloat(1))
         }
+        
+        #if canImport(UIKit)
+        public func makeUIColor() -> UIColor {
+            return makePlatformNativeColor()
+        }
+        #elseif canImport(AppKit)
+        public func makeNSColor() -> NSColor {
+            return makePlatformNativeColor()
+        }
+        #endif
     }
 
     enum ColorChannel {

--- a/ColorThiefSwift/Classes/MMCQ.swift
+++ b/ColorThiefSwift/Classes/MMCQ.swift
@@ -17,7 +17,11 @@
 //  Sven Woltmann - for the fast Java Implementation
 //  https://github.com/SvenWoltmann/color-thief-java
 
+#if canImport(UIKit)
 import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 /// MMCQ (modified median cut quantization) algorithm from
 /// the Leptonica library (http://www.leptonica.com/).
@@ -54,8 +58,8 @@ open class MMCQ {
             self.b = b
         }
 
-        public func makeUIColor() -> UIColor {
-            return UIColor(red: CGFloat(r) / CGFloat(255), green: CGFloat(g) / CGFloat(255), blue: CGFloat(b) / CGFloat(255), alpha: CGFloat(1))
+        public func makePlatformNativeColor() -> PlatformNativeColor {
+            return PlatformNativeColor(red: CGFloat(r) / CGFloat(255), green: CGFloat(g) / CGFloat(255), blue: CGFloat(b) / CGFloat(255), alpha: CGFloat(1))
         }
     }
 

--- a/ColorThiefSwift/Info.plist
+++ b/ColorThiefSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.1</string>
+	<string>0.4.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Example/ColorThiefSwiftExample/ViewController.swift
+++ b/Example/ColorThiefSwiftExample/ViewController.swift
@@ -60,14 +60,14 @@ class ViewController: UIViewController, UIImagePickerControllerDelegate, UINavig
                 for i in 0 ..< 9 {
                     if i < colors.count {
                         let color = colors[i]
-                        self?.paletteViews[i].backgroundColor = color.makeUIColor()
+                        self?.paletteViews[i].backgroundColor = color.makePlatformNativeColor()
                         self?.paletteLabels[i].text = "getPalette[\(i)] R\(color.r) G\(color.g) B\(color.b)"
                     } else {
                         self?.paletteViews[i].backgroundColor = UIColor.white
                         self?.paletteLabels[i].text = "-"
                     }
                 }
-                self?.colorView.backgroundColor = dominantColor.makeUIColor()
+                self?.colorView.backgroundColor = dominantColor.makePlatformNativeColor()
                 self?.colorLabel.text = "getColor R\(dominantColor.r) G\(dominantColor.g) B\(dominantColor.b)"
             }
         }

--- a/Example/ColorThiefSwiftExample/ViewController.swift
+++ b/Example/ColorThiefSwiftExample/ViewController.swift
@@ -60,14 +60,14 @@ class ViewController: UIViewController, UIImagePickerControllerDelegate, UINavig
                 for i in 0 ..< 9 {
                     if i < colors.count {
                         let color = colors[i]
-                        self?.paletteViews[i].backgroundColor = color.makePlatformNativeColor()
+                        self?.paletteViews[i].backgroundColor = color.makeUIColor()
                         self?.paletteLabels[i].text = "getPalette[\(i)] R\(color.r) G\(color.g) B\(color.b)"
                     } else {
                         self?.paletteViews[i].backgroundColor = UIColor.white
                         self?.paletteLabels[i].text = "-"
                     }
                 }
-                self?.colorView.backgroundColor = dominantColor.makePlatformNativeColor()
+                self?.colorView.backgroundColor = dominantColor.makeUIColor()
                 self?.colorLabel.text = "getColor R\(dominantColor.r) G\(dominantColor.g) B\(dominantColor.b)"
             }
         }

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -1,16 +1,20 @@
 import ColorThiefSwift
+#if canImport(UIKit)
 import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 import XCTest
 
 class Tests: XCTestCase {
 
-    var image: UIImage!
+    var image: PlatformNativeImage!
 
     override func setUp() {
         super.setUp()
         let bundle = Bundle(for: type(of: self))
         let path = bundle.path(forResource: "pen", ofType: "jpg")!
-        image = UIImage(contentsOfFile: path)
+        image = PlatformNativeImage(contentsOfFile: path)
     }
 
     override func tearDown() {
@@ -208,12 +212,25 @@ class Tests: XCTestCase {
     func testSmallWidthImage() {
         let width = 1
         let height = 16
+        
+        #if canImport(UIKit)
         UIGraphicsBeginImageContext(CGSize(width: width, height: height))
         let context = UIGraphicsGetCurrentContext()
         context!.setFillColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
         context!.fill(CGRect(x: 0, y: 0, width: width, height: height))
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
+        #elseif canImport(AppKit)
+        let image = NSImage(size: NSSize(width: width, height: height))
+        image.lockFocus()
+        guard let context = NSGraphicsContext.current?.cgContext else {
+            XCTFail("Failed to get CGContext")
+            return
+        }
+        NSColor.white.setFill()
+        context.fill(NSRect(x: 0, y: 0, width: width, height: height))
+        image.unlockFocus()
+        #endif
 
         let color = ColorThief.getColor(from: image!, quality: 1, ignoreWhite: false)
         XCTAssertNotNil(color)
@@ -222,12 +239,24 @@ class Tests: XCTestCase {
     func testSmallWidthBlackImage() {
         let width = 1
         let height = 16
+        #if canImport(UIKit)
         UIGraphicsBeginImageContext(CGSize(width: width, height: height))
         let context = UIGraphicsGetCurrentContext()
         context!.setFillColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)
         context!.fill(CGRect(x: 0, y: 0, width: width, height: height))
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
+        #elseif canImport(AppKit)
+        let image = NSImage(size: NSSize(width: width, height: height))
+        image.lockFocus()
+        guard let context = NSGraphicsContext.current?.cgContext else {
+            XCTFail("Failed to get CGContext")
+            return
+        }
+        NSColor.black.setFill()
+        context.fill(NSRect(x: 0, y: 0, width: width, height: height))
+        image.unlockFocus()
+        #endif
 
         let color = ColorThief.getColor(from: image!, quality: 1, ignoreWhite: false)
         XCTAssertNotNil(color)

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,12 @@ import PackageDescription
 
 let package = Package(
     name: "ColorThiefSwift",
-    platforms: [.iOS(.v10)],
+    platforms: [
+        .iOS(.v9),
+        .tvOS(.v9),
+        .watchOS(.v2),
+        .macOS(.v10_11)
+    ],
     products: [
         .library(name: "ColorThiefSwift", targets: ["ColorThiefSwift"])
     ],

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 
 - Xcode 10.2
 - Swift 5
-- iOS 9
+- iOS 9, macOS 10.11, tvOS 9, or watchOS 2
 
 ## Installation
 
@@ -28,7 +28,7 @@ ColorThiefSwift is available through [CocoaPods](http://cocoapods.org). To insta
 it, simply add the following line to your Podfile:
 
 ```ruby
-pod 'ColorThiefSwift', '>= 0.4.1'
+pod 'ColorThiefSwift', '>= 0.4.2'
 ```
 
 ### Carthage
@@ -36,7 +36,7 @@ pod 'ColorThiefSwift', '>= 0.4.1'
 Add this to Cartfile
 
 ```
-github "yamoridon/ColorThiefSwift" ~> 0.4.1
+github "yamoridon/ColorThiefSwift" ~> 0.4.2
 ```
 
 ```


### PR DESCRIPTION
Hi, thank you so much for this wonderful library. I've been using it now alongside SwiftUI in some side projects to pull the dominant colors from album art. 😄

I'm not sure if you're accepting pull requests, but I've added support for macOS (as well as defined support for tvOS and watchOS in the package file and podspec) and thought I would offer it back in case you would like to incorporate it into the repo.

The bulk of the change is a typedef called `PlatformNativeImage` that resolves to `UIImage` if UIKit is available or `NSImage` if AppKit is available. Please feel free to edit as you see fit, and thanks for your consideration.